### PR TITLE
Update sqlfluff in pre-commit to resolve mysterious error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # All available hooks: https://pre-commit.com/hooks.html
 repos:
   - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 2.1.1
+    rev: 3.4.0
     hooks:
     -   id: sqlfluff-lint
     -   id: sqlfluff-fix


### PR DESCRIPTION
The sqlfluff pre-commit hook has started failing with [mysterious CLI errors](https://github.com/ccao-data/public/actions/runs/14978515925/job/42076782970#step:7:72) that I'm able to reproduce locally on the main branch. I don't understand what could have changed since [the last time we successfully ran pre-commit a few weeks ago](https://github.com/ccao-data/public/actions/runs/14621147723), because sqlfluff is pinned to [a specific historical version](https://github.com/sqlfluff/sqlfluff/releases/tag/2.1.1) and that version hasn't changed in either this repo or https://github.com/sqlfluff/sqlfluff/:

https://github.com/ccao-data/public/blob/5c05f347242fa7fd036f09e2792961ae1ea9ab7b/.pre-commit-config.yaml#L4

Rather than spend too much time finding the root cause of these error messages, I confirmed that other repos that use sqlfluff on different versions are not facing the same problem, and I upgraded sqlfluff to the latest version in this repo to resolve the error.